### PR TITLE
Fix purchase bug

### DIFF
--- a/client/src/api/index.js
+++ b/client/src/api/index.js
@@ -34,16 +34,9 @@ export const addItemToInventory = async (inventory, item) => {
 
 export const deductCoin = async (userCoin, amount) => {
     const updatedCoin = userCoin - amount
-
-    if (updatedCoin === 0) {
-        await axios.put('/api/profile/info', {
-            coin: Math.floor(0.0001), // Set coin to null to remove the value
-        })
-    } else {
-        await axios.put('/api/profile/info', {
-            coin: updatedCoin,
-        })
-    }
+    await axios.put('/api/profile/info', {
+        coin: updatedCoin.toString(), // Explicitly set to string to account for 0
+    })
 }
 
 export const removeItemFromInventory = async (inventory, item) => {


### PR DESCRIPTION
Currently, `deductCoin` does not properly set the user's balance to zero. This allows for users to indefinitely purchase packs without actually paying if the user's balance is the exact amount of the pack price e.g. `coin balance: 60, common pack cost: 60`.

This PR proposes to fix this by explicitly stringifying the new balance in the put request.